### PR TITLE
New feature - display current bundle name

### DIFF
--- a/BundlingAndMinificationForTheMasses/Bundles.cs
+++ b/BundlingAndMinificationForTheMasses/Bundles.cs
@@ -16,7 +16,7 @@
         {
             var doc = XDocument.Load(HttpContext.Current.Server.MapPath(Config.BundlesConfigPath));
             var files = new List<string>();
-            var disableMinifcation = false;
+            var disableMinification = false;
 
             if (doc.Descendants(bundleType + "Bundle")
                    .Any(x => x.Attribute("virtualPath").Value == virtualPath))
@@ -25,14 +25,14 @@
                 var bundleElement = doc.Descendants(bundleType + "Bundle")
                                         .Single(x => x.Attribute("virtualPath").Value == virtualPath);
 
-                disableMinifcation = bundleElement.Attribute("disableMinification") != null ? bundleElement.Attribute("disableMinification").Value == true.ToString() : false;
-                
-                foreach (var file in bundleElement.Descendants())
-                {
-                    files.Add(file.Attribute("virtualPath").Value);
-                }
+                disableMinification = bundleElement.Attribute("disableMinification") != null && bundleElement.Attribute("disableMinification").Value == true.ToString(); // simplified
+
+	            files.AddRange(bundleElement.Descendants().Select(file => file.Attribute("virtualPath").Value)); 
             }
-            return new BundleViewModel { VirtualPath = virtualPath, DisableMinification = disableMinifcation, Files = files };
+
+	        string path = string.Format("{0}{1}", bundleType, virtualPath.Replace('~','s')); // text for current bundle being edited
+
+            return new BundleViewModel { VirtualPath = virtualPath, DisableMinification = disableMinification, Files = files, EditPath = path}; // constructor
         }
 
         public static void SaveBundleFromViewModel(BundleViewModel bundle, string bundleType)

--- a/BundlingAndMinificationForTheMasses/Controllers/BundleController.cs
+++ b/BundlingAndMinificationForTheMasses/Controllers/BundleController.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
-using System.Xml.Linq;
 using Optimus.Models;
-using Optimus.Umbraco;
 using Umbraco.Web.Mvc;
 using HtmlAgilityPack;
 

--- a/BundlingAndMinificationForTheMasses/Models/BundleViewModel.cs
+++ b/BundlingAndMinificationForTheMasses/Models/BundleViewModel.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Web;
 
 namespace Optimus.Models
 {
+	/// <summary>
+	/// Main front-end Optimus view model.
+	/// </summary>
     public class BundleViewModel
     {
         [Display(Name = "Virtual path:")]
@@ -16,5 +16,11 @@ namespace Optimus.Models
 
         [Display(Name = "Files in bundle:")]
         public IEnumerable<string> Files { get; set; }
+
+		/// <summary>
+		/// Optimus bundling section's header bar text.
+		/// </summary>
+		[Display(Name = "Editing:")]
+	    public string EditPath { get; set; }
     }
 }

--- a/BundlingAndMinificationForTheMasses/Views/Index.cshtml
+++ b/BundlingAndMinificationForTheMasses/Views/Index.cshtml
@@ -238,24 +238,25 @@
 
             <div class="umb-pane ">
                 <div class="control-group umb-control-group">
+					<div>
+						@*@Html.EditorFor(m => m.DisableMinification)*@
+						@Html.LabelFor(m => m.EditPath)<span class="umb-abstract">@(Model.EditPath)</span>
+					</div>
+					@* <div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    <p class="umb-abstract">Edit Bundle</p>
+							@Html.EditorFor(m => m.VirtualPath)
+							<br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
+						</div>
+					</div>
+					<div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    @* <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.VirtualPath)
-                                <br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
-                            </div>
-                        </div>
-                        <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.DisableMinification)
-                            </div>
-                        </div>*@
+							@Html.EditorFor(m => m.DisableMinification)
+						</div>
+					</div>*@
                     <div class="umb-el-wrap ">
                         @Html.LabelFor(m => m.Files, new { @class = "control-label" })
                         <div class="controls controls-row">
@@ -271,21 +272,12 @@
                     </div>
                 </div>
             </div>
-
         </div>
-
-
-
-
     </body>
 }
 else
 {
-
-
     <body>
-
-
         <div id="body_UmbracoPanel" class="panel" style="width:100%;">
             <div class="boxhead">
                 <h2 id="body_UmbracoPanelLabel">Bundle Editor</h2>

--- a/TestSite/App_Plugins/Optimus/Views/Index.cshtml
+++ b/TestSite/App_Plugins/Optimus/Views/Index.cshtml
@@ -238,24 +238,25 @@
 
             <div class="umb-pane ">
                 <div class="control-group umb-control-group">
+					<div>
+						@*@Html.EditorFor(m => m.DisableMinification)*@
+						@Html.LabelFor(m => m.EditPath)<span class="umb-abstract">@(Model.EditPath)</span>
+					</div>
+					@* <div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    <p class="umb-abstract">Edit Bundle</p>
+							@Html.EditorFor(m => m.VirtualPath)
+							<br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
+						</div>
+					</div>
+					<div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    @* <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.VirtualPath)
-                                <br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
-                            </div>
-                        </div>
-                        <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.DisableMinification)
-                            </div>
-                        </div>*@
+							@Html.EditorFor(m => m.DisableMinification)
+						</div>
+					</div>*@
                     <div class="umb-el-wrap ">
                         @Html.LabelFor(m => m.Files, new { @class = "control-label" })
                         <div class="controls controls-row">
@@ -271,21 +272,12 @@
                     </div>
                 </div>
             </div>
-
         </div>
-
-
-
-
     </body>
 }
 else
 {
-
-
     <body>
-
-
         <div id="body_UmbracoPanel" class="panel" style="width:100%;">
             <div class="boxhead">
                 <h2 id="body_UmbracoPanelLabel">Bundle Editor</h2>

--- a/TestSiteV7/App_Plugins/Optimus/Views/Index.cshtml
+++ b/TestSiteV7/App_Plugins/Optimus/Views/Index.cshtml
@@ -238,24 +238,25 @@
 
             <div class="umb-pane ">
                 <div class="control-group umb-control-group">
+					<div>
+						@*@Html.EditorFor(m => m.DisableMinification)*@
+						@Html.LabelFor(m => m.EditPath)<span class="umb-abstract">@(Model.EditPath)</span>
+					</div>
+					@* <div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    <p class="umb-abstract">Edit Bundle</p>
+							@Html.EditorFor(m => m.VirtualPath)
+							<br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
+						</div>
+					</div>
+					<div class="umb-el-wrap ">
+						@Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
+						<div class="controls controls-row">
 
-                    @* <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.VirtualPath, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.VirtualPath)
-                                <br/><small>use with @@@{@exampleScript}.Render("@Model.VirtualPath")</small>
-                            </div>
-                        </div>
-                        <div class="umb-el-wrap ">
-                            @Html.LabelFor(m => m.DisableMinification, new { @class = "control-label" })
-                            <div class="controls controls-row">
-
-                                @Html.EditorFor(m => m.DisableMinification)
-                            </div>
-                        </div>*@
+							@Html.EditorFor(m => m.DisableMinification)
+						</div>
+					</div>*@
                     <div class="umb-el-wrap ">
                         @Html.LabelFor(m => m.Files, new { @class = "control-label" })
                         <div class="controls controls-row">
@@ -271,21 +272,12 @@
                     </div>
                 </div>
             </div>
-
         </div>
-
-
-
-
     </body>
 }
 else
 {
-
-
     <body>
-
-
         <div id="body_UmbracoPanel" class="panel" style="width:100%;">
             <div class="boxhead">
                 <h2 id="body_UmbracoPanelLabel">Bundle Editor</h2>


### PR DESCRIPTION
Added text indicating the name of the bundle currently visible and/or being edited in the Optimus editor section.
